### PR TITLE
change license: Public Domain -> MIT

### DIFF
--- a/test/m2penc/LICENSE.txt
+++ b/test/m2penc/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Yoji Suzuki.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/test/m2penc/README.md
+++ b/test/m2penc/README.md
@@ -157,9 +157,9 @@ video:600kB audio:554kB subtitle:0kB other streams:0kB global headers:0kB muxing
 
 ## License
 
-本プログラム（[src/m2penc.cpp](src/m2penc.cpp)）のライセンスは Public Domain とします。
+本プログラム（[src/m2penc.cpp](src/m2penc.cpp)）のライセンスは [MIT](LICENSE.txt) とします。
 
-ただし、以下のソフトウェアに依存しているため、再配布時にはそれぞれのライセンス条項の遵守をお願いいたします。
+また、本プログラムには以下のソフトウェアに依存しているため、再配布時にはそれぞれのライセンス条項の遵守をお願いいたします。
 
 - JSON for Modern C++
   - Web Site: [https://github.com/nlohmann/json](https://github.com/nlohmann/json)

--- a/test/m2penc/src/m2penc.cpp
+++ b/test/m2penc/src/m2penc.cpp
@@ -1,5 +1,29 @@
-// Playlog to MP4 movie encoder
-// License: Public Domain
+/**
+ * Playlog to MP4 movie encoder
+ * -----------------------------------------------------------------------------
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Yoji Suzuki.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * -----------------------------------------------------------------------------
+ */
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/performance/LICENSE.txt
+++ b/test/performance/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Yoji Suzuki.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -19,3 +19,22 @@ Frame usage: 20.21%
 - `Total time` : 3600フレームの実行に要した時間
 - `Frame average` : 1フレームの実行に要した平均時間
 - `Frame usage` : 60Hzでの垂直同期を入れた1フレームの時間（1000÷60ms）に対してコア実行に要する時間の比率（想定CPU使用率）
+
+## License
+
+本プログラム（[test.cpp](test.cpp)）のライセンスは [MIT](LICENSE.txt) とします。
+
+また、本プログラムには以下のソフトウェアに依存しているため、再配布時にはそれぞれのライセンス条項の遵守をお願いいたします。
+
+- emu2413
+  - Web Site: [https://github.com/digital-sound-antiques/emu2413](https://github.com/digital-sound-antiques/emu2413)
+  - License: [MIT](../../licenses-copy/emu2413.txt)
+  - `Copyright (c) 2001-2019 Mitsutaka Okazaki`
+- SUZUKI PLAN - Z80 Emulator
+  - Web Site: [https://github.com/suzukiplan/z80](https://github.com/suzukiplan/z80)
+  - License: [MIT](../../licenses-copy/z80.txt)
+  - `Copyright (c) 2019 Yoji Suzuki.`
+- micro MSX2+
+  - Web Site: [https://github.com/suzukiplan/micro-msx2p](https://github.com/suzukiplan/micro-msx2p)
+  - License: [MIT](../../LICENSE.txt)
+  - `Copyright (c) 2023 Yoji Suzuki.`

--- a/test/performance/test.cpp
+++ b/test/performance/test.cpp
@@ -1,3 +1,29 @@
+/**
+ * Performance Tester
+ * -----------------------------------------------------------------------------
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Yoji Suzuki.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * -----------------------------------------------------------------------------
+ */
 #include "../../msx2-osx/core/msx2.hpp"
 #include <chrono>
 

--- a/test/runbas/LICENSE.txt
+++ b/test/runbas/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Yoji Suzuki.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/test/runbas/README.md
+++ b/test/runbas/README.md
@@ -118,9 +118,9 @@ Writing result.bmp...
 
 ## License
 
-本プログラム（[runbas.cpp](runbas.cpp)）のライセンスは Public Domain とします。
+本プログラム（[runbas.cpp](runbas.cpp)）のライセンスは [MIT](LICENSE.txt) とします。
 
-ただし、以下のソフトウェアに依存しているため、再配布時にはそれぞれのライセンス条項の遵守をお願いいたします。
+また、本プログラムには以下のソフトウェアに依存しているため、再配布時にはそれぞれのライセンス条項の遵守をお願いいたします。
 
 - LZ4 Library
   - Web Site: [https://github.com/lz4/lz4](https://github.com/lz4/lz4) - [lib](https://github.com/lz4/lz4/tree/dev/lib)

--- a/test/runbas/runbas.cpp
+++ b/test/runbas/runbas.cpp
@@ -1,5 +1,29 @@
-// MSX-BASIC Runner
-// License: Public Domain
+/**
+ * MSX-BASIC Runner for CLI
+ * -----------------------------------------------------------------------------
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Yoji Suzuki.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * -----------------------------------------------------------------------------
+ */
 #include "../../msx2-osx/core/msx2.hpp"
 
 typedef struct BitmapHeader_ {


### PR DESCRIPTION
test ディレクトリ以下のモジュール（現時点では m2penc, performance, runbas）のライセンスを Public Domain にしていたが、日本の法律下では著作者財産権（著作権）の放棄や譲渡は可能と解釈されるが著作者人格権の放棄できるかは微妙らしい。（[参考](https://copyright.watson.jp/renounce.shtml)）

そのため、[NYSL](http://www.kmonos.net/nysl/)と呼ばれる、著作者財産権は放棄しつつ著作者人格権は維持するライセンス規定が存在する。

なお、test ディレクトリ以下のライセンスを Public Domain にしていた理由としては、micro-msx2pを用いたサンプル実装という位置づけにしたかったためであり、本体ライセンス（MIT）よりも緩くしたかったという意図があるので、NYSLへ変更することが妥当だと考えられる。

しかし、NYSLは世界的に認知されたライセンス規定ではないため、採用してしまうとMITよりも使い難くなるリスク（いちいち弁護士なりの法律チェックが必要など）があると思われる。

そこで、testディレクトリ以下も本体ライセンスに合わせて MIT ライセンスとする。

なお、testディレクトリ以下のライセンスは本体ライセンスと同一化はしない。（本体ライセンスは 2-clause BSD、MIT、Apache License 2.0あたりに限定することが、MSX〜MSX2+のゲーム作者にとって最も自由度が高いと思われるが、test以下ではGPL等も積極的に使う方針なので本体ライセンスと一本化すると使い難くなってしまう筈）