### PR TITLE
disable PSRAM

### DIFF
--- a/msx1-m5stack/platformio.ini
+++ b/msx1-m5stack/platformio.ini
@@ -2,7 +2,8 @@
 platform = espressif32
 board = m5stack-core2
 framework = arduino
-build_unflags = -Os 
-build_flags = -Ofast -DZ80_DISABLE_DEBUG -DZ80_DISABLE_BREAKPOINT -DZ80_DISABLE_NESTCHECK
+board_build.extra_flags = 
+build_unflags = -Os -DBOARD_HAS_PSRAM
+build_flags = -Ofast -DCORE_DEBUG_LEVEL=5 -DZ80_DISABLE_DEBUG -DZ80_DISABLE_BREAKPOINT -DZ80_DISABLE_NESTCHECK
 monitor_speed = 115200
 lib_deps = M5Core2, M5GFX


### PR DESCRIPTION
CORE_DEBUG_LEVEL を設定してブートログを確認したところ `psramInit(): PSRAM enabled` が実行されていた。

```
rst:0x1 (POWERON_RESET),boot:0x17 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:1184
load:0x40078000,len:13192
load:0x40080400,len:3028
entry 0x400805e4
[    10][D][esp32-hal-cpu.c:244] setCpuFrequencyMhz(): PLL: 480 / 2 = 240 Mhz, APB: 80000000 Hz
[   459][I][esp32-hal-psram.c:96] psramInit(): PSRAM enabled
M5Core2 initializing...[   527][I][esp32-hal-i2c.c:75] i2cInit(): Initialising I2C Master: sda=21 scl=22 freq=100000
```

現状の RAM usage  は 79940 bytes なので PSRAM を OFF にしても動ける筈。

```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   1.8% (used 79940 bytes from 4521984 bytes)
Flash: [=         ]  11.4% (used 745613 bytes from 6553600 bytes)
Building .pio/build/m5stack-core2/firmware.bin
```
