### PR TITLE
Disable WDT of Core0 and execute ticker task on Core0 without vTaskDelay

### DIFF
--- a/msx1-m5stack/src/app.cpp
+++ b/msx1-m5stack/src/app.cpp
@@ -67,8 +67,7 @@ void ticker(void* arg)
             fps = 60;
             vTaskDelay(expect - procTime);
         } else {
-            fps = 2000 / (procTime + 1);
-            vTaskDelay(1);
+            fps = 2000 / procTime;
         }
         loopCount++;
         loopCount %= 3;
@@ -137,8 +136,9 @@ void setup() {
     booted = true;
     usleep(1000000);
     gfx.clear();
-    xTaskCreatePinnedToCore(ticker, "ticker", 4096, nullptr, 25, nullptr, 1);
-    xTaskCreatePinnedToCore(renderer, "renderer", 4096, nullptr, 25, nullptr, 0);
+    disableCore0WDT();
+    xTaskCreatePinnedToCore(ticker, "ticker", 4096, nullptr, 25, nullptr, 0);
+    xTaskCreatePinnedToCore(renderer, "renderer", 4096, nullptr, 25, nullptr, 1);
 }
 
 void loop() {


### PR DESCRIPTION
ticker タスクで 2フレーム実行の処理時間が 30fps に追いつかなかった時 `vTaskDelay(1)` でウェイトを入れており、これを外すと動かなくなるが、これは FreeRTOS の WDT (watchdog timer) に起因する問題で、WDT は（片方のCPUに限り）OFF にすることができ、OFF にすれば余分な `vTaskDelay(1)` を外すことができる。（処理落ちが微妙に軽減される）