### PR TITLE
メニューキャンセル

### DIFF
--- a/msx1-m5stack/src/app.cpp
+++ b/msx1-m5stack/src/app.cpp
@@ -819,7 +819,7 @@ inline void menuLoop()
         gamepad.updatePush();
     }
 
-    if (buttons[ButtonPosition::Center]->wasPressed() || gamepad.wasPushStart || gamepad.wasPushA || gamepad.wasPushB || gamepad.wasPushSelect) {
+    if (buttons[ButtonPosition::Center]->wasPressed() || gamepad.wasPushStart || gamepad.wasPushA) {
         switch (menuItems[menuCursor]) {
             case MenuItem::Resume:
                 pref.save();
@@ -880,6 +880,8 @@ inline void menuLoop()
         if (menuCursor < 0) {
             menuCursor = (int)menuItems.size() - 1;
         }
+    } else if (gamepad.wasPushB || gamepad.wasPushSelect) {
+        menuCursor = 0;
     }
     gfx.startWrite();
     for (int i = 0; i < menuItems.size(); i++) {

--- a/src1/tms9918a.hpp
+++ b/src1/tms9918a.hpp
@@ -570,7 +570,7 @@ class TMS9918A
                     }
                     if (0 == dlog[x]) {
                         if (this->ctx->ram[cur] & bit[j / ac.mag]) {
-                            if (rendering) renderPosition[x] = this->palette[col];
+                            if (rendering && col) renderPosition[x] = this->palette[col];
                             dlog[x] = col;
                             wlog[x] = 1;
                         }
@@ -585,7 +585,7 @@ class TMS9918A
                         }
                         if (0 == dlog[x]) {
                             if (this->ctx->ram[cur] & bit[j / ac.mag]) {
-                                if (rendering) renderPosition[x] = this->palette[col];
+                                if (rendering && col) renderPosition[x] = this->palette[col];
                                 dlog[x] = col;
                                 wlog[x] = 1;
                             }


### PR DESCRIPTION
メニューの操作をしている時、カーソルをRESUMEに戻して復帰操作をするのがやや野暮ったいので、B or SELECTを押せば一発でメニューカーソルをトップ（RESUME）へ移動させる仕様に変更する。

現時点のメニュー操作仕様（Gamepad使用時）

|ボタン|動作|
|:-|:-|
|上カーソル|カーソルを-1|
|下カーソル|カーソルを+1|
|左カーソル|選択項目にカーソルがある場合のみ、項目を-1|
|右カーソル|選択項目にカーソルがある場合のみ、項目を+1|
|A|選択項目にカーソルがある場合、項目を+1 `OR` 非選択項目の場合はENTER|
|START|Aと等価|
|B|カーソルをトップ(0)へ移動|~
|SELECT|Bと等価|
