### PR TITLE
Z80関連の不具合修正+α

### DIFF
--- a/src/ay8910.hpp
+++ b/src/ay8910.hpp
@@ -78,8 +78,8 @@ class AY8910
 
     inline void setPads(unsigned char pad1, unsigned char pad2)
     {
-        this->ctx.reg[0x0E] = (~pad1) & 0x7F;
-        this->ctx.reg[0x0F] = (~pad2) & 0x7F;
+        this->ctx.reg[0x0E] = (~pad1) & 0xFF;
+        this->ctx.reg[0x0F] = (~pad2) & 0xFF;
     }
 
     inline void write(unsigned char value)

--- a/src/msx2.hpp
+++ b/src/msx2.hpp
@@ -194,6 +194,7 @@ class MSX2
         this->kanji = new MSX2Kanji();
         this->cpu = new Z80([](void* arg, unsigned short addr) { return ((MSX2*)arg)->mmu->read(addr); }, [](void* arg, unsigned short addr, unsigned char value) { ((MSX2*)arg)->mmu->write(addr, value); }, [](void* arg, unsigned short port) { return ((MSX2*)arg)->inPort((unsigned char)port); }, [](void* arg, unsigned short port, unsigned char value) { ((MSX2*)arg)->outPort((unsigned char)port, value); }, this, false);
         this->cpu->wtc.fetch = 1;
+        this->cpu->wtc.fetchM = 1;
         this->scc = nullptr;
 #ifndef MSX2_REMOVE_OPLL
         if (ym2413Enabled) {

--- a/src/z80.hpp
+++ b/src/z80.hpp
@@ -41,9 +41,10 @@ class Z80
 {
   public: // Interface data types
     struct WaitClocks {
-        int fetch; // Wait T-cycle (Hz) before fetching instruction (default is 0 = no wait)
-        int read;  // Wait T-cycle (Hz) before to read memory (default is 0 = no wait)
-        int write; // Wait T-cycle (Hz) before to write memory (default is 0 = no wait)
+        int fetch;  // Wait T-cycle (Hz) before fetching instruction (default is 0 = no wait)
+        int fetchM; // Wait T-cycle (Hz) before fetching multi-bytes instruction (default is 0 = no wait)
+        int read;   // Wait T-cycle (Hz) before to read memory (default is 0 = no wait)
+        int write;  // Wait T-cycle (Hz) before to write memory (default is 0 = no wait)
     } wtc;
 
     struct RegisterPair {
@@ -655,7 +656,7 @@ class Z80
 
     static inline void OP_CB(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
 #ifndef Z80_DISABLE_BREAKPOINT
         ctx->checkBreakOperandCB(operandNumber);
 #endif
@@ -664,7 +665,7 @@ class Z80
 
     static inline void OP_ED(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetED[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (ED,%02X)", operandNumber);
@@ -678,7 +679,7 @@ class Z80
 
     static inline void OP_IX(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetIX[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (DD,%02X)", operandNumber);
@@ -692,7 +693,7 @@ class Z80
 
     static inline void OP_IY(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetIY[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (FD,%02X)", operandNumber);

--- a/src1/ay8910.hpp
+++ b/src1/ay8910.hpp
@@ -90,8 +90,8 @@ class AY8910
 
     inline void setPads(unsigned char pad1, unsigned char pad2)
     {
-        this->ctx.reg[0x0E] = (~pad1) & 0x7F;
-        this->ctx.reg[0x0F] = (~pad2) & 0x7F;
+        this->ctx.reg[0x0E] = (~pad1) & 0xFF;
+        this->ctx.reg[0x0F] = (~pad2) & 0xFF;
     }
 
     inline void write(unsigned char value)

--- a/src1/msx1.hpp
+++ b/src1/msx1.hpp
@@ -50,8 +50,8 @@ class MSX1
     } psgDelegate;
 #endif
   private:
-    const int CPU_CLOCK = 3584160;
-    const int VDP_CLOCK = 5376240;
+    const int CPU_CLOCK = 3579545;
+    const int VDP_CLOCK = 5370863;
 
 #ifndef MSX1_REMOVE_PSG
     const int PSG_CLOCK = 44100;

--- a/src1/msx1.hpp
+++ b/src1/msx1.hpp
@@ -179,6 +179,7 @@ class MSX1
             colorMode, this, [](void* arg) { ((MSX1*)arg)->cpu.generateIRQ(0x07); }, [](void* arg) { ((MSX1*)arg)->cpu.requestBreak(); }, displayCallback, vram);
         this->cpu.setupCallbackFP([](void* arg, unsigned short addr) { return ((MSX1*)arg)->mmu.read(addr); }, [](void* arg, unsigned short addr, unsigned char value) { ((MSX1*)arg)->mmu.write(addr, value); }, [](void* arg, unsigned short port) { return ((MSX1*)arg)->inPort(port); }, [](void* arg, unsigned short port, unsigned char value) { ((MSX1*)arg)->outPort((unsigned char)port, value); }, this, false);
         this->cpu.wtc.fetch = 1;
+        this->cpu.wtc.fetchM = 1;
         this->cpu.setConsumeClockCallbackFP([](void* arg, int cpuClocks) {
             ((MSX1*)arg)->consumeClock(cpuClocks);
         });

--- a/src1/z80.hpp
+++ b/src1/z80.hpp
@@ -41,9 +41,10 @@ class Z80
 {
   public: // Interface data types
     struct WaitClocks {
-        int fetch; // Wait T-cycle (Hz) before fetching instruction (default is 0 = no wait)
-        int read;  // Wait T-cycle (Hz) before to read memory (default is 0 = no wait)
-        int write; // Wait T-cycle (Hz) before to write memory (default is 0 = no wait)
+        int fetch;  // Wait T-cycle (Hz) before fetching instruction (default is 0 = no wait)
+        int fetchM; // Wait T-cycle (Hz) before fetching multi-bytes instruction (default is 0 = no wait)
+        int read;   // Wait T-cycle (Hz) before to read memory (default is 0 = no wait)
+        int write;  // Wait T-cycle (Hz) before to write memory (default is 0 = no wait)
     } wtc;
 
     struct RegisterPair {
@@ -655,7 +656,7 @@ class Z80
 
     static inline void OP_CB(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
 #ifndef Z80_DISABLE_BREAKPOINT
         ctx->checkBreakOperandCB(operandNumber);
 #endif
@@ -664,7 +665,7 @@ class Z80
 
     static inline void OP_ED(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetED[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (ED,%02X)", operandNumber);
@@ -678,7 +679,7 @@ class Z80
 
     static inline void OP_IX(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetIX[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (DD,%02X)", operandNumber);
@@ -692,7 +693,7 @@ class Z80
 
     static inline void OP_IY(Z80* ctx)
     {
-        unsigned char operandNumber = ctx->fetch(4);
+        unsigned char operandNumber = ctx->fetch(4 + ctx->wtc.fetchM);
         if (!ctx->opSetIY[operandNumber]) {
             char buf[80];
             snprintf(buf, sizeof(buf), "detect an unknown operand (FD,%02X)", operandNumber);


### PR DESCRIPTION
MSXのZ80のCPUクロックレートを以下を参考に調整する。

https://taku.izumisawa.jp/Msx/ktecho2

結果的に命令あたりの CPU クロック数が増えるので #17 も若干程度改善されるかもしれない。

_ついでにMSX1のCPUとVDPクロックレートが誤っているので調整する_