### PR TITLE
rpizero, rpizero2版MSX1コアのPSG音量が小さい

### DIFF
--- a/msx1-rpizero/kernel_run.cpp
+++ b/msx1-rpizero/kernel_run.cpp
@@ -43,14 +43,13 @@ TShutdownMode CKernel::run(void)
     MSX1 msx1(TMS9918A::ColorMode::RGB565, ram, sizeof(ram), &vram, [](void* arg, int frame, int line, unsigned short* display) {
         memcpy(&hdmiBuffer[line * hdmiPitch], display, 512);
     });
-    msx1.psg.setVolume(4);
     msx1.setup(0, 0, (void*)rom_cbios_main_msx1, 0x8000, "MAIN");
     msx1.setup(0, 4, (void*)rom_cbios_logo_msx1, 0x4000, "LOGO");
     msx1.setupKeyAssign(0, MSX1_JOY_S1, ' ');                              // start button: SPACE
     msx1.setupKeyAssign(0, MSX1_JOY_S2, 0x1B);                             // select button: ESC
     msx1.loadRom((void*)rom_game, sizeof(rom_game), MSX1_ROM_TYPE_NORMAL); // modify here if use mega rom
     msx1.reset();
-    sound.SetControl(VCHIQ_SOUND_VOLUME_MAX);
+    msx1.psg.setVolume(4);
 
     // main loop
     int swap = 0;

--- a/msx1-rpizero2/kernel_run.cpp
+++ b/msx1-rpizero2/kernel_run.cpp
@@ -44,14 +44,13 @@ TShutdownMode CKernel::run(void)
     MSX1 msx1(TMS9918A::ColorMode::RGB565, ram, sizeof(ram), &vram, [](void* arg, int frame, int line, unsigned short* display) {
         memcpy(&hdmiBuffer[line * hdmiPitch], display, 512);
     });
-    msx1.psg.setVolume(4);
     msx1.setup(0, 0, (void*)rom_cbios_main_msx1, 0x8000, "MAIN");
     msx1.setup(0, 4, (void*)rom_cbios_logo_msx1, 0x4000, "LOGO");
     msx1.setupKeyAssign(0, MSX1_JOY_S1, ' ');                              // start button: SPACE
     msx1.setupKeyAssign(0, MSX1_JOY_S2, 0x1B);                             // select button: ESC
     msx1.loadRom((void*)rom_game, sizeof(rom_game), MSX1_ROM_TYPE_NORMAL); // modify here if use mega rom
     msx1.reset();
-    sound.SetControl(VCHIQ_SOUND_VOLUME_MAX);
+    msx1.psg.setVolume(4);
 
     // main loop
     int swap = 0;


### PR DESCRIPTION
ボリュームのシフト設定誤りを修正（reset後にセットが必要）